### PR TITLE
Update update-gitops.yaml

### DIFF
--- a/.github/workflows/update-gitops.yaml
+++ b/.github/workflows/update-gitops.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout GitOps repository
         uses: actions/checkout@v4
         with:
-          repository: mischavandenburg/devops-study-app-gitops
+          repository: bmacharia/devops-study-app-gitops
           ref: main
           path: devops-study-app-gitops
           ssh-key: ${{ secrets.GITOPS_DEPLOY_KEY }}


### PR DESCRIPTION
This pull request updates the GitOps configuration in the `.github/workflows/update-gitops.yaml` file. Specifically, it changes the repository reference for the GitOps checkout step.

* [`.github/workflows/update-gitops.yaml`](diffhunk://#diff-6f809c41cbb454580cb2488ee41bac92aad0056984f89ca671623416dbbdccabL37-R37): Updated the `repository` field in the "Checkout GitOps repository" job to use `bmacharia/devops-study-app-gitops` instead of `mischavandenburg/devops-study-app-gitops`.